### PR TITLE
Ajout metadata s'appuyant sur les modèles de projet ANSSI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# Contribution à ce projet
+
+Merci de votre intérêt pour ce projet. Veuillez lire attentivement ce document avant de considérer toute contribution.
+
+## Portée des contributions
+
+Ce projet accepte des contributions visant à proposer à l'ANSSI des améliorations du contenu technique pointé par le guide ANSSI [Sécuriser la 
+journalisation dans un environnement Microsoft Active 
+Directory](https://messervices.cyber.gouv.fr/guides/securiser-la-journalisation-dans-un-environnement-microsoft-active-directory).
+Il est également possible de suggérer l'ajout de nouvelles idées qui ne seraient pas traitées dans la version en vigueur du guide. L'ANSSI étudiera
+la pertinence de votre proposition.
+
+## Support utilisateur
+
+Pour toute question relative au guide ANSSI [Sécuriser la journalisation dans un environnement Microsoft Active 
+Directory](https://messervices.cyber.gouv.fr/guides/securiser-la-journalisation-dans-un-environnement-microsoft-active-directory), envoyer un mail à
+l'adresse conseil.technique@ssi.gouv.fr.
+
+## Comment contribuer
+
+1. Assurez-vous que votre contribution est strictement liée à la portée des contributions explicitée ci-dessus.
+2. Clonez le dépôt et créez une nouvelle branche pour votre travail.
+3. Soumettez une _pull request_ avec une description claire de vos suggestions d'amélioration.
+
+## Problème de sécurité
+
+Si vous découvrez un problème de sécurité dans ce projet, veuillez le signaler selon la politique de sécurité décrite dans le fichier `SECURITY.md`.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
+# Guide journalisation Microsoft
+
+<img src="https://www.sgdsn.gouv.fr/files/styles/ds_image_paragraphe/public/files/Notre_Organisation/logo_anssi.png" alt="Logo ANSSI" width="30%">
+
+## Agence nationale de la sécurité des systèmes d'information
+
+![badge_repo](https://img.shields.io/badge/ANSSI--FR-guide--journalisation--microsoft-white)
+[![badge_catégorie_doctrinal](https://img.shields.io/badge/catégorie-doctrinal-%23e9c7e7)](https://github.com/ANSSI-FR#types-de-projets)
+[![badge_ouverture_B](https://img.shields.io/badge/code.gouv.fr-ouvert-green)](https://documentation.ouvert.numerique.gouv.fr/les-parcours-de-documentation/ouvrir-un-projet-num%C3%A9rique/#niveau-ouverture)
+
+*Ce projet est édité par l'[ANSSI](https://cyber.gouv.fr/). Pour en savoir plus, voir la [page dédiée à la stratégie open source de l'ANSSI](https://cyber.gouv.fr/open-source-lanssi). Vous pouvez également cliquer sur les badges pour en savoir plus sur leur signification.*
+
 Ce dépôt met à disposition le contenu technique pointé par le guide https://www.ssi.gouv.fr/journalisation-windows de l'ANSSI.
 
 > [!WARNING]

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@
 
 *Ce projet est édité par l'[ANSSI](https://cyber.gouv.fr/). Pour en savoir plus, voir la [page dédiée à la stratégie open source de l'ANSSI](https://cyber.gouv.fr/open-source-lanssi). Vous pouvez également cliquer sur les badges pour en savoir plus sur leur signification.*
 
-Ce dépôt met à disposition le contenu technique pointé par le guide https://www.ssi.gouv.fr/journalisation-windows de l'ANSSI.
+Ce dépôt met à disposition le contenu technique pointé par le guide  guide ANSSI [Sécuriser la 
+journalisation dans un environnement Microsoft Active 
+Directory](https://messervices.cyber.gouv.fr/guides/securiser-la-journalisation-dans-un-environnement-microsoft-active-directory).
 
 > [!WARNING]
 > Plusieurs problèmes ont été identifiés sur la collecte des journaux systèmes Windows, vraisemblablement liés à la migration de serveurs WEC vers Windows Server 2025.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# Politique de sécurité
+
+## Signalement d’une vulnérabilité
+
+Si vous découvrez une vulnérabilité dans ce projet, veuillez nous aider à la gérer de manière responsable en suivant ces étapes :
+
+1. **Ne divulguez pas publiquement la vulnérabilité.**
+2. Contactez-nous directement en créant un nouveau rapport de sécurité décrivant votre découverte. Alternativement, vous pouvez envoyer un mail à [opensource@ssi.gouv.fr](mailto:opensource@ssi.gouv.fr) en nous fournissant les détails suivants :
+    * Une description claire du problème.
+    * Les étapes pour reproduire la vulnérabilité.
+    * Toute incidence potentielle ou scénarios d’exploitation possibles.
+
+Merci pour votre aide à maintenir ce projet sécurisé !

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,10 +1,10 @@
 # Politique de sécurité
 
-## Signalement d’une vulnérabilité
+## Signalement d’un problème de sécurité
 
-Si vous découvrez une vulnérabilité dans ce projet, veuillez nous aider à la gérer de manière responsable en suivant ces étapes :
+Si vous découvrez un problème de sécurité dans ce projet, veuillez nous aider à le gérer de manière responsable en suivant ces étapes :
 
-1. **Ne divulguez pas publiquement la vulnérabilité.**
+1. **Ne divulguez pas publiquement le problème de sécurité.**
 2. Contactez-nous directement en créant un nouveau rapport de sécurité décrivant votre découverte. Alternativement, vous pouvez envoyer un mail à [opensource@ssi.gouv.fr](mailto:opensource@ssi.gouv.fr) en nous fournissant les détails suivants :
     * Une description claire du problème.
     * Les étapes pour reproduire la vulnérabilité.


### PR DESCRIPTION
Hello,

Dans le contexte de la publication de la [stratégie open source de l'ANSSI](https://cyber.gouv.fr/enjeux-technologiques/open-source/), nous cherchons à aligner l'identité visuelle des différents dépôts de code l'ANSSI. Cette _pull request_ vise à intégrer différents éléments, issus des [modèles fournis](https://github.com/ANSSI-FR/template) :

- README.md : lien vers la stratégie open source de l'ANSSI et intégration de « badges » donnant le [type de projet](https://github.com/ANSSI-FR/#types-de-projets) et le [niveau d'ouverture](https://github.com/ANSSI-FR/#niveau-douverture)

- CONTRIBUTING.md : explications sur le type de contributions attendues

- SECURITY.md : politique de sécurité et méthode de remontée d'éventuels problèmes de sécurité

N'hésite pas à commenter la pull request et à éventuellement amender le contenu en fonction des spécificités du projet.